### PR TITLE
Added new functionality for generating image IDs for storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.idea
 *.log
 *hibernate.cfg.xml
+/arfna-backend/src/main/resources/org.arfna.util.security/credentials.json

--- a/api-service/src/main/java/org/arfna/service/CacheHelper.java
+++ b/api-service/src/main/java/org/arfna/service/CacheHelper.java
@@ -17,6 +17,9 @@ public class CacheHelper {
 
     public static String addValue(Object value) {
         String generatedKey = RandomStringUtils.randomAlphanumeric(30);
+        while (COOKIE_CACHE.containsKey(generatedKey)) {
+            generatedKey = RandomStringUtils.randomAlphanumeric(30);
+        }
         COOKIE_CACHE.put(generatedKey, value);
         return generatedKey;
     }

--- a/api-service/src/main/java/org/arfna/service/ESupportedEndpoints.java
+++ b/api-service/src/main/java/org/arfna/service/ESupportedEndpoints.java
@@ -7,6 +7,7 @@ public enum ESupportedEndpoints {
     MUTATE_POST_TABLE("mpost"),
     GET_POST("gpost"),
     READ_SUBSCRIBER_COOKIE("rsubscriber"),
+    IMAGE_ID("rimageid")
     ;
 
     private String endpointName;

--- a/api-service/src/main/java/org/arfna/service/ServiceClient.java
+++ b/api-service/src/main/java/org/arfna/service/ServiceClient.java
@@ -40,6 +40,11 @@ public class ServiceClient {
         return util.getSubscriberCookieResponse(json, loggedInSubscriber);
     }
 
+    private MethodResponse imageIdResponse(String json, Optional<Subscriber> loggedInSubscriber) {
+        ArfnaUtility util = new ArfnaUtility();
+        return util.imageIdResponse(json, loggedInSubscriber);
+    }
+
     public ApiResponse execute(InputStream jsonStream, String endpoint, Optional<Subscriber> loggedInSubscriber) {
         ApiResponse apiResponse;
         try {
@@ -61,7 +66,12 @@ public class ServiceClient {
                 MethodResponse methodResponse = getSubscriberCookieResponse(payload, loggedInSubscriber);
                 apiResponse = methodResponse.isUnauthorized() ? generateNotAuthorizedResponse() :
                         generateSuccessResponse(methodResponse);
-            } else {
+            } else if (endpoint.contains(ESupportedEndpoints.IMAGE_ID.getEndpointName())) {
+                MethodResponse methodResponse = imageIdResponse(payload, loggedInSubscriber);
+                apiResponse = methodResponse.isUnauthorized() ? generateNotAuthorizedResponse() :
+                        generateSuccessResponse(methodResponse);
+            }
+            else {
                 ArfnaLogger.error(this.getClass(), endpoint + " is not a supported endpoint");
                 apiResponse = generateFailureResponse(400, "Unsupported endpoint");
             }

--- a/arfna-backend/README.md
+++ b/arfna-backend/README.md
@@ -163,6 +163,21 @@ It will throw an unauthorized error if the cookie is not valid anymore.
 }
 ```
 
+## Working with the image storage S3 DB (`rimageid`)
+This API is used for interacting and reading keys from S3, as well as ensuring a user has the right permissions with a post and the ARFNA application prior to pushing files to the S3 database. It requires a user to be logged in as a writer or above in order to use.
+
+**Generating a key for image storage**
+It will throw an unauthorized error if the subscriber is not the author of the given post; a subscriber can override this check if the subscriber is at least of `maint` role.
+```json
+{
+	"version": "V1",
+	"requestType": "GENERATE_ID",
+	"post": {
+		"id": 7
+	}
+}
+```
+
 
 ## Validation and Error Codes
 Every response is sent back with the following format

--- a/arfna-backend/pom.xml
+++ b/arfna-backend/pom.xml
@@ -13,11 +13,24 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>1.12.221</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
     <dependencies>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
+            <version>1.2.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jmx</groupId>
@@ -49,7 +62,7 @@
             <artifactId>gson</artifactId>
             <version>2.8.8</version>
         </dependency>
-<!--       database-->
+        <!--       database-->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
@@ -66,6 +79,24 @@
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!--    AWS S3 -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+        </dependency>
+        <!-- jaxb bind for later versions of java -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/arfna-backend/src/main/java/org/arfna/api/ArfnaUtility.java
+++ b/arfna-backend/src/main/java/org/arfna/api/ArfnaUtility.java
@@ -51,6 +51,13 @@ public class ArfnaUtility {
         return util.getResponse(jsonPayload, version, subscriber);
     }
 
+    public MethodResponse imageIdResponse(String jsonPayload, Optional<Subscriber> subscriber) {
+        ArfnaLogger.info(this.getClass(), "Received request to image id api");
+        EVersion version = getVersion(jsonPayload);
+        ImageIdUtility util = new ImageIdUtility();
+        return util.getResponse(jsonPayload, version, subscriber);
+    }
+
     private EVersion getVersion(String jsonPayload) {
         ArfnaVersion version = GsonHelper.getGson().fromJson(jsonPayload, ArfnaVersion.class);
         return version.getVersion();

--- a/arfna-backend/src/main/java/org/arfna/api/endpoints/ImageIdUtility.java
+++ b/arfna-backend/src/main/java/org/arfna/api/endpoints/ImageIdUtility.java
@@ -1,0 +1,25 @@
+package org.arfna.api.endpoints;
+
+import org.arfna.api.version.EVersion;
+import org.arfna.database.entity.Subscriber;
+import org.arfna.method.blog.images.ImageIdPayload;
+import org.arfna.method.blog.images.ImageIdResponse;
+import org.arfna.method.password.middleware.ESubscriberRole;
+import org.arfna.util.gson.GsonHelper;
+
+import java.util.Optional;
+
+public class ImageIdUtility {
+
+    public ImageIdResponse getResponse(String inputPayload, EVersion version, Optional<Subscriber> subscriber) {
+        boolean isSubscriberAuthorized = version.getMiddlewareHelper().isSubscriberAuthorized(subscriber, ESubscriberRole.WRITER_ROLE);
+        if (!isSubscriberAuthorized) {
+            ImageIdResponse unauthorizedResponse = new ImageIdResponse();
+            unauthorizedResponse.setUnauthorized();
+            return unauthorizedResponse;
+        }
+        ImageIdPayload payload = GsonHelper.getGson().fromJson(inputPayload, ImageIdPayload.class);
+        return version.getImageIdApi().getResponse(payload, version, subscriber.get());
+    }
+
+}

--- a/arfna-backend/src/main/java/org/arfna/api/version/EVersion.java
+++ b/arfna-backend/src/main/java/org/arfna/api/version/EVersion.java
@@ -1,8 +1,11 @@
 package org.arfna.api.version;
 
 import org.arfna.database.DatabaseUtil;
+import org.arfna.database.s3.S3Util;
 import org.arfna.method.blog.GetBlogApiV1;
 import org.arfna.method.blog.IGetBlogApi;
+import org.arfna.method.blog.images.IImageIdApi;
+import org.arfna.method.blog.images.ImageIdApiV1;
 import org.arfna.method.blog.mutation.IMutatePostApi;
 import org.arfna.method.blog.mutation.MutatePostApiV1;
 import org.arfna.method.cookie.subscriber.ISubscriberCookieApi;
@@ -18,27 +21,31 @@ import org.arfna.method.password.middleware.MiddlewareHelperV1;
 
 public enum EVersion {
 
-    V1(new DummyApiV1(), new MutateSubscriberApiV1(), new MutatePostApiV1(), new GetBlogApiV1(), new SubscriberCookieApiV1(),
-            new MiddlewareHelperV1(), new DatabaseUtil(), new PasswordHelperV1());
+    V1(new DummyApiV1(), new MutateSubscriberApiV1(), new MutatePostApiV1(), new GetBlogApiV1(), new ImageIdApiV1(),
+            new SubscriberCookieApiV1(), new MiddlewareHelperV1(), new DatabaseUtil(), new S3Util(), new PasswordHelperV1());
 
     private IDummyApi dummyAPI;
     private IMutateSubscriberApi mutateSubscriberApi;
     private IMutatePostApi mutatePostApi;
     private IGetBlogApi getBlogApi;
+    private IImageIdApi imageIdApi;
     private ISubscriberCookieApi subscriberCookieApi;
     private IMiddlewareHelper middlewareHelper;
     private DatabaseUtil databaseUtil;
+    private S3Util s3Util;
     private IPasswordHelper passwordHelper;
 
-    EVersion(IDummyApi dummyAPI, IMutateSubscriberApi mutateSubscriberApi, IMutatePostApi mutatePostApi, IGetBlogApi getBlogApi,
-             ISubscriberCookieApi subscriberCookieApi, IMiddlewareHelper middlewareHelper, DatabaseUtil databaseUtil, IPasswordHelper passwordHelper) {
+    EVersion(IDummyApi dummyAPI, IMutateSubscriberApi mutateSubscriberApi, IMutatePostApi mutatePostApi, IGetBlogApi getBlogApi, IImageIdApi imageIdApi,
+             ISubscriberCookieApi subscriberCookieApi, IMiddlewareHelper middlewareHelper, DatabaseUtil databaseUtil, S3Util s3Util, IPasswordHelper passwordHelper) {
         this.dummyAPI = dummyAPI;
         this.mutateSubscriberApi = mutateSubscriberApi;
         this.mutatePostApi = mutatePostApi;
         this.getBlogApi = getBlogApi;
+        this.imageIdApi = imageIdApi;
         this.subscriberCookieApi = subscriberCookieApi;
         this.middlewareHelper = middlewareHelper;
         this.databaseUtil = databaseUtil;
+        this.s3Util = s3Util;
         this.passwordHelper = passwordHelper;
     }
 
@@ -72,5 +79,13 @@ public enum EVersion {
 
     public ISubscriberCookieApi getSubscriberCookieApi() {
         return subscriberCookieApi;
+    }
+
+    public IImageIdApi getImageIdApi() {
+        return imageIdApi;
+    }
+
+    public S3Util getS3Util() {
+        return s3Util;
     }
 }

--- a/arfna-backend/src/main/java/org/arfna/database/s3/AwsCredentials.java
+++ b/arfna-backend/src/main/java/org/arfna/database/s3/AwsCredentials.java
@@ -1,0 +1,21 @@
+package org.arfna.database.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import org.arfna.util.security.SecurityKey;
+
+public class AwsCredentials implements AWSCredentialsProvider {
+
+    @Override
+    public AWSCredentials getCredentials() {
+        SecurityKey key = SecurityKey.getSecurityKeys();
+        return new BasicAWSCredentials(key.getAwsIamKey().getAccessKey(), key.getAwsIamKey().getSecretKey());
+    }
+
+    @Override
+    public void refresh() {
+        // do nothing
+    }
+
+}

--- a/arfna-backend/src/main/java/org/arfna/database/s3/S3Util.java
+++ b/arfna-backend/src/main/java/org/arfna/database/s3/S3Util.java
@@ -1,0 +1,82 @@
+package org.arfna.database.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Prior to using this class, please ensure that your aws credentials have been set on this machine
+ * This should be in your root directory, in the .aws/credentials file
+ */
+public class S3Util {
+
+    private static final String BUCKET_NAME = "arfna-images";
+
+    private static AmazonS3 S3_CLIENT;
+
+    public List<String> getAllFileNames() {
+        ListObjectsV2Result result = getS3Client().listObjectsV2(BUCKET_NAME);
+        List<S3ObjectSummary> objects = result.getObjectSummaries();
+        return objects.stream().map(S3ObjectSummary::getKey).collect(Collectors.toList());
+    }
+
+    public Set<String> getAllFilesInPath(String path) {
+        ListObjectsV2Result result = getS3Client().listObjectsV2(BUCKET_NAME, path);
+        List<S3ObjectSummary> objects = result.getObjectSummaries();
+        return objects.stream()
+                .map(S3ObjectSummary::getKey)
+                .map(x -> x.replaceAll(path, ""))
+                .collect(Collectors.toSet());
+    }
+
+    public boolean isFileInS3(String path) {
+        ListObjectsV2Result result = getS3Client().listObjectsV2(BUCKET_NAME, path);
+        List<S3ObjectSummary> objects = result.getObjectSummaries();
+        return !objects.isEmpty();
+    }
+
+    public void uploadFile(String localFile, String pathToUpload) {
+        getS3Client().putObject(BUCKET_NAME, pathToUpload, new File(localFile));
+    }
+
+    public void deleteFile(String pathToDelete) {
+        getS3Client().deleteObject(BUCKET_NAME, pathToDelete);
+    }
+
+    private static AmazonS3 getS3Client() {
+        if (S3_CLIENT == null) {
+            S3_CLIENT = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new AwsCredentials())
+                    .withRegion(Regions.US_EAST_1)
+                    .build();
+        }
+        return S3_CLIENT;
+    }
+
+    public static void main(String[] args) {
+        S3Util util = new S3Util();
+        util.getAllFileNames().forEach(System.out::println);
+        System.out.println();
+        util.getAllFilesInPath("thumbnails/").forEach(System.out::println);
+        System.out.println();
+        System.out.println(util.isFileInS3("thumbnails/tiger.png"));
+        System.out.println(util.isFileInS3("thumbnails/bat.png"));
+        util.uploadFile(System.getProperty("user.home") + File.separator + String.join(File.separator, "Downloads", "swarm.png"),
+                "test/swarm.png");
+        System.out.println();
+        util.getAllFileNames().forEach(System.out::println);
+        System.out.println();
+        util.deleteFile("test/swarm.png");
+    }
+
+}

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/EImageRequest.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/EImageRequest.java
@@ -1,0 +1,7 @@
+package org.arfna.method.blog.images;
+
+public enum EImageRequest {
+
+    GENERATE_ID
+
+}

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/IImageIdApi.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/IImageIdApi.java
@@ -1,0 +1,11 @@
+package org.arfna.method.blog.images;
+
+import org.arfna.api.version.ArfnaVersion;
+import org.arfna.api.version.EVersion;
+import org.arfna.database.entity.Subscriber;
+
+public interface IImageIdApi {
+
+    ImageIdResponse getResponse(ImageIdPayload payload, EVersion version, Subscriber subscriber);
+
+}

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdApiV1.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdApiV1.java
@@ -14,7 +14,7 @@ public class ImageIdApiV1 implements IImageIdApi {
         if (requestType == EImageRequest.GENERATE_ID) {
             ImageIdHelper helper = new ImageIdHelper();
             ArfnaLogger.debug(this.getClass(), "Checking permissions for ID generation");
-            if (helper.checkIfValidWritePermission(payload, version, subscriber)) {
+            if (!helper.checkIfValidWritePermission(payload, version, subscriber)) {
                 ImageIdResponse response = new ImageIdResponse();
                 response.setUnauthorized();
                 return response;

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdApiV1.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdApiV1.java
@@ -1,0 +1,30 @@
+package org.arfna.method.blog.images;
+
+import org.arfna.api.version.EVersion;
+import org.arfna.database.entity.Subscriber;
+import org.arfna.method.common.EValidationMessage;
+import org.arfna.method.common.ValidationMessage;
+import org.arfna.util.logger.ArfnaLogger;
+
+public class ImageIdApiV1 implements IImageIdApi {
+
+    @Override
+    public ImageIdResponse getResponse(ImageIdPayload payload, EVersion version, Subscriber subscriber) {
+        EImageRequest requestType = payload.getRequestType();
+        if (requestType == EImageRequest.GENERATE_ID) {
+            ImageIdHelper helper = new ImageIdHelper();
+            ArfnaLogger.debug(this.getClass(), "Checking permissions for ID generation");
+            if (helper.checkIfValidWritePermission(payload, version, subscriber)) {
+                ImageIdResponse response = new ImageIdResponse();
+                response.setUnauthorized();
+                return response;
+            }
+            ArfnaLogger.debug(this.getClass(), "Generating unique id for image");
+            return helper.generateImageId(payload, version, subscriber);
+        }
+        ImageIdResponse response = new ImageIdResponse();
+        response.addValidationMessage(new ValidationMessage(EValidationMessage.INVALID_API));
+        return response;
+    }
+
+}

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdHelper.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdHelper.java
@@ -1,0 +1,55 @@
+package org.arfna.method.blog.images;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.arfna.api.version.EVersion;
+import org.arfna.database.entity.Post;
+import org.arfna.database.entity.Subscriber;
+import org.arfna.method.password.middleware.ESubscriberRole;
+import org.arfna.util.logger.ArfnaLogger;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ImageIdHelper {
+
+    ImageIdResponse generateImageId(ImageIdPayload payload, EVersion version, Subscriber subscriber) {
+        int subscriberId = subscriber.getId();
+        int postId = payload.getPost().getId();
+        String s3Path = this.generateId(subscriberId, postId);
+        String generatedId = generateValidId(s3Path, version);
+        return new ImageIdResponse().withImageId(this.generateId(subscriberId, postId, generatedId));
+    }
+
+    boolean checkIfValidWritePermission(ImageIdPayload payload, EVersion version, Subscriber subscriber) {
+        boolean subscriberAuthored = validateSubscriberAuthoredPost(payload.getPost(), version, subscriber);
+        if (subscriberAuthored)
+            return true;
+        return validateSubscriberHasFullEdit(subscriber, version);
+    }
+
+    private boolean validateSubscriberAuthoredPost(Post p, EVersion version, Subscriber s) {
+        ArfnaLogger.debug(this.getClass(), "Getting post from database");
+        Post postFromDatabase = version.getDatabaseUtil().getPost(p.getId());
+        return postFromDatabase.getAuthor().getId() == s.getId();
+    }
+
+    private boolean validateSubscriberHasFullEdit(Subscriber s, EVersion version) {
+        return version.getMiddlewareHelper().isSubscriberAuthorized(Optional.of(s), ESubscriberRole.MAINT_ROLE);
+    }
+
+    String generateId(Object ... ids) {
+        return Arrays.stream(ids).map(Object::toString).collect(Collectors.joining("ab/"));
+    }
+
+    String generateValidId(String s3Path, EVersion version) {
+        ArfnaLogger.debug(this.getClass(), "Fetching all image files from S3");
+        Set<String> fileNamesAlreadyTaken = version.getS3Util().getAllFilesInPath(s3Path);
+        String generatedId = RandomStringUtils.randomAlphanumeric(15);
+        while (fileNamesAlreadyTaken.contains(generatedId)) {
+            generatedId = RandomStringUtils.randomAlphanumeric(15);
+        }
+        return generatedId;
+    }
+}

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdPayload.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdPayload.java
@@ -1,0 +1,21 @@
+package org.arfna.method.blog.images;
+
+import com.google.gson.annotations.Expose;
+import org.arfna.database.entity.Post;
+
+import java.io.Serializable;
+
+public class ImageIdPayload implements Serializable {
+    private static final long serialVersionUID = 2829523806918065888L;
+
+    @Expose private EImageRequest requestType;
+    @Expose private Post post;
+
+    public EImageRequest getRequestType() {
+        return requestType;
+    }
+
+    public Post getPost() {
+        return post;
+    }
+}

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdResponse.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdResponse.java
@@ -1,0 +1,17 @@
+package org.arfna.method.blog.images;
+
+import com.google.gson.annotations.Expose;
+import org.arfna.method.common.MethodResponse;
+
+import java.io.Serializable;
+
+public class ImageIdResponse extends MethodResponse implements Serializable {
+    private static final long serialVersionUID = 6646388683784852349L;
+
+    @Expose private String imageId;
+
+    public ImageIdResponse withImageId(String imageId) {
+        this.imageId = imageId;
+        return this;
+    }
+}

--- a/arfna-backend/src/main/java/org/arfna/util/files/ResourceHelper.java
+++ b/arfna-backend/src/main/java/org/arfna/util/files/ResourceHelper.java
@@ -13,13 +13,13 @@ public class ResourceHelper {
     public static URL getResourceAsUrl(Class<?> clazz, String filename) {
         return clazz
                 .getClassLoader()
-                .getResource(clazz.getPackage().getName() + File.separator + filename);
+                .getResource(clazz.getPackage().getName() + "/" + filename);
     }
 
     public static InputStream getResourceAsStream(Class<?> clazz, String filename) {
         return clazz
                 .getClassLoader()
-                .getResourceAsStream(clazz.getPackage().getName() + File.separator + filename);
+                .getResourceAsStream(clazz.getPackage().getName() + "/" + filename);
     }
 
 }

--- a/arfna-backend/src/main/java/org/arfna/util/security/AwsIamKey.java
+++ b/arfna-backend/src/main/java/org/arfna/util/security/AwsIamKey.java
@@ -1,0 +1,26 @@
+package org.arfna.util.security;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+public class AwsIamKey implements Serializable {
+    private static final long serialVersionUID = -6515150040484858874L;
+
+    @Expose
+    @SerializedName("access_key")
+    private String accessKey;
+
+    @Expose
+    @SerializedName("secret_key")
+    private String secretKey;
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+}

--- a/arfna-backend/src/main/java/org/arfna/util/security/SecurityKey.java
+++ b/arfna-backend/src/main/java/org/arfna/util/security/SecurityKey.java
@@ -1,0 +1,39 @@
+package org.arfna.util.security;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import org.arfna.util.files.ResourceHelper;
+import org.arfna.util.gson.GsonHelper;
+import org.arfna.util.logger.ArfnaLogger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class SecurityKey {
+
+    private static SecurityKey SECURITY_KEY;
+
+    @Expose
+    @SerializedName("aws_role")
+    private AwsIamKey awsIamKey;
+
+    private SecurityKey() {
+        // restrict instantiation
+    }
+
+    public AwsIamKey getAwsIamKey() {
+        return awsIamKey;
+    }
+
+    public static SecurityKey getSecurityKeys() {
+        if (SECURITY_KEY == null) {
+            try (InputStream stream = ResourceHelper.getResourceAsStream(SecurityKey.class, "credentials.json")) {
+                SECURITY_KEY = GsonHelper.getGson().fromJson(new InputStreamReader(stream), SecurityKey.class);
+            } catch (IOException e) {
+                ArfnaLogger.exception(SecurityKey.class, "Unable to get security keys: " + e.getMessage(), e);
+            }
+        }
+        return SECURITY_KEY;
+    }
+}

--- a/arfna-backend/src/main/resources/org.arfna.util.security/template_credentials.json
+++ b/arfna-backend/src/main/resources/org.arfna.util.security/template_credentials.json
@@ -1,0 +1,7 @@
+// Rename to credentials.json and REMOVE this line
+{
+  "aws_role": {
+    "access_key": "XXXXXXX",
+    "secret_key": "XXXXXXX"
+  }
+}

--- a/arfna-backend/src/test/java/org/arfna/api/ArfnaUtilityTest.java
+++ b/arfna-backend/src/test/java/org/arfna/api/ArfnaUtilityTest.java
@@ -1,8 +1,8 @@
 package org.arfna.api;
 
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.arfna.method.common.MethodResponse;
 import org.arfna.util.gson.GsonHelper;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
This PR tackles a couple minor bugs as well as including an S3 client for generating image IDs and any other interactions with the database in the future.

Due to https://github.com/aws/aws-sdk-java/issues/2772 it does not work when the `jetty` server is launched. We are still looking into alternatives with this. 

If wanting to test the API in anyway, simply comment out https://github.com/roshnee99/backend-arfna/blob/db8109b1408b9b4ad1db83f3cb1cfb47a1e67ad2/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdHelper.java#L48 so that the S3 client never gets initialized, as that is where the code breaks. So just set it to an empty HashSet and you should be fine.