### PR TITLE
Added status codes to header of requests

### DIFF
--- a/api-service/src/main/java/org/arfna/api/Status.java
+++ b/api-service/src/main/java/org/arfna/api/Status.java
@@ -18,4 +18,8 @@ public class Status implements Serializable {
         this.code = code;
         this.message = message;
     }
+
+    public int getCode() {
+        return code;
+    }
 }

--- a/server/src/main/java/org/arfna/Servlet.java
+++ b/server/src/main/java/org/arfna/Servlet.java
@@ -52,6 +52,7 @@ public class Servlet extends HttpServlet {
             Optional<Subscriber> subscriberCookie = getSubscriberCookie(request);
             ApiResponse apiResponse = client.execute(request.getInputStream(), endpoint[1], subscriberCookie);
             addCookies(apiResponse, response);
+            response.setStatus(apiResponse.getStatus().getCode());
             response.getWriter().println(GsonHelper.getGsonWithPrettyPrint().toJson(apiResponse));
         }
     }


### PR DESCRIPTION
Old behavior did not add status codes to the header. This fix ensures that the status code is added to the headers of the request.

Also ensures that when validation checks do not pass, creates a status code `412` error claiming that preconditions failed before modifying table (validation failed 😄 )

