### PR TITLE
Removed requirements for log in DB

### DIFF
--- a/arfna-backend/src/main/java/org/arfna/api/endpoints/ImageIdUtility.java
+++ b/arfna-backend/src/main/java/org/arfna/api/endpoints/ImageIdUtility.java
@@ -12,14 +12,15 @@ import java.util.Optional;
 public class ImageIdUtility {
 
     public ImageIdResponse getResponse(String inputPayload, EVersion version, Optional<Subscriber> subscriber) {
-        boolean isSubscriberAuthorized = version.getMiddlewareHelper().isSubscriberAuthorized(subscriber, ESubscriberRole.WRITER_ROLE);
-        if (!isSubscriberAuthorized) {
-            ImageIdResponse unauthorizedResponse = new ImageIdResponse();
-            unauthorizedResponse.setUnauthorized();
-            return unauthorizedResponse;
-        }
+//        boolean isSubscriberAuthorized = version.getMiddlewareHelper().isSubscriberAuthorized(subscriber, ESubscriberRole.WRITER_ROLE);
+//        if (!isSubscriberAuthorized) {
+//            ImageIdResponse unauthorizedResponse = new ImageIdResponse();
+//            unauthorizedResponse.setUnauthorized();
+//            return unauthorizedResponse;
+//        }
         ImageIdPayload payload = GsonHelper.getGson().fromJson(inputPayload, ImageIdPayload.class);
-        return version.getImageIdApi().getResponse(payload, version, subscriber.get());
+        Subscriber mockSubscriber = new Subscriber().setId(671).setRole(ESubscriberRole.ADMIN_ROLE.getRoleName());
+        return version.getImageIdApi().getResponse(payload, version, mockSubscriber);
     }
 
 }

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdApiV1.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdApiV1.java
@@ -13,12 +13,12 @@ public class ImageIdApiV1 implements IImageIdApi {
         EImageRequest requestType = payload.getRequestType();
         if (requestType == EImageRequest.GENERATE_ID) {
             ImageIdHelper helper = new ImageIdHelper();
-            ArfnaLogger.debug(this.getClass(), "Checking permissions for ID generation");
-            if (!helper.checkIfValidWritePermission(payload, version, subscriber)) {
-                ImageIdResponse response = new ImageIdResponse();
-                response.setUnauthorized();
-                return response;
-            }
+//            ArfnaLogger.debug(this.getClass(), "Checking permissions for ID generation");
+//            if (!helper.checkIfValidWritePermission(payload, version, subscriber)) {
+//                ImageIdResponse response = new ImageIdResponse();
+//                response.setUnauthorized();
+//                return response;
+//            }
             ArfnaLogger.debug(this.getClass(), "Generating unique id for image");
             return helper.generateImageId(payload, version, subscriber);
         }

--- a/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdHelper.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdHelper.java
@@ -52,4 +52,10 @@ public class ImageIdHelper {
         }
         return generatedId;
     }
+
+    public static void main(String[] args) {
+        ImageIdHelper helper = new ImageIdHelper();
+        System.out.println("Generated ID: " + helper.generateValidId("671ab/9", EVersion.V1));
+        System.out.println("SUCCESS!");
+    }
 }


### PR DESCRIPTION
In order to recreate the S3 error in this case

1. Head to https://github.com/roshnee99/backend-arfna/blob/project/v1/arfna-backend/src/main/resources/org.arfna.util.security/template_credentials.json and rename the file to `credentials.json`. Add any IAM role secret and access key that has access to an S3 bucket. Remove the comment on line 1.
2. In https://github.com/roshnee99/backend-arfna/blob/project/v1/arfna-backend/src/main/java/org/arfna/database/s3/S3Util.java, set `BUCKET_NAME` to a bucket that the IAM has access to.
3. In `arfna-main` module, run `mvn clean install -DskipTests -U`
4. To start the server, run `mvn jetty:run -f pom.xml` in the `server` module
5. The server will start in `localhost:8080`

To make the offending request in jetty environment, make a POST request to endpoint `http://localhost:8080/arfna/api/rimageid` with the following JSON payload 
```
{
	"version": "V1",
	"requestType": "GENERATE_ID",
	"post": {
		"id": 9
	}
}
```
A stack trace will be thrown on the server side.


### Additional Info
In a main method, you can see that this error does not occur by running the following: https://github.com/roshnee99/backend-arfna/blob/6807ea6a6b9e85f8ec617d4803b692a0f6de9060/arfna-backend/src/main/java/org/arfna/method/blog/images/ImageIdHelper.java#L56

