### PR TITLE
CU-8669715eh Update version of httpclient for AWS Secrets

### DIFF
--- a/api-service/pom.xml
+++ b/api-service/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/arfna-backend/pom.xml
+++ b/arfna-backend/pom.xml
@@ -146,10 +146,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
-    <!--        AWS Secrets Manager -->
+    <!--        AWS Secrets Manager and client for secrets -->
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>secretsmanager</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.2</version>
     </dependency>
 
     </dependencies>

--- a/arfna-backend/pom.xml
+++ b/arfna-backend/pom.xml
@@ -146,15 +146,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-    <!--        AWS Secrets Manager and client for secrets -->
+    <!--        AWS Secrets Manager -->
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>secretsmanager</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.5.2</version>
     </dependency>
 
     </dependencies>


### PR DESCRIPTION
We get the below error when the EC2 instance tries to fetch the AWS Secrets credentials
```
[qtp380894366-11] WARN   - HHH000342: Could not obtain connection to query metadata : null
[qtp380894366-11] INFO   - HHH000400: Using dialect: org.hibernate.dialect.MySQL5Dialect
[qtp380894366-11] INFO   - HHH000422: Disabling contextual LOB creation as connection was null
[qtp380894366-11] WARN   - SQL Error: 0, SQLState: 08S01
[qtp380894366-11] ERROR  - Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
[qtp380894366-11] ERROR  - 2023-01-02T03:51:26.983214   |       org.arfna.database.DatabaseUtil |       message: Exception occurred when checking if subscriber exists
org.hibernate.service.spi.ServiceException: Unable to create requested service [org.hibernate.engine.jdbc.env.spi.JdbcEnvironment]
        at org.hibernate.service.internal.AbstractServiceRegistryImpl.createService(AbstractServiceRegistryImpl.java:275)
        at org.hibernate.service.internal.AbstractServiceRegistryImpl.initializeService(AbstractServiceRegistryImpl.java:237)
        at org.hibernate.service.internal.AbstractServiceRegistryImpl.getService(AbstractServiceRegistryImpl.java:214)
        at org.hibernate.id.factory.internal.DefaultIdentifierGeneratorFactory.injectServices(DefaultIdentifierGeneratorFactory.java:152)
        at org.hibernate.service.internal.AbstractServiceRegistryImpl.injectDependencies(AbstractServiceRegistryImpl.java:286)
        at org.hibernate.service.internal.AbstractServiceRegistryImpl.initializeService(AbstractServiceRegistryImpl.java:243)
        at org.hibernate.service.internal.AbstractServiceRegistryImpl.getService(AbstractServiceRegistryImpl.java:214)
        at org.hibernate.boot.internal.InFlightMetadataCollectorImpl.<init>(InFlightMetadataCollectorImpl.java:179)
        at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.complete(MetadataBuildingProcess.java:119)
        at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.build(MetadataBuildingProcess.java:84)
        at org.hibernate.boot.internal.MetadataBuilderImpl.build(MetadataBuilderImpl.java:474)
        at org.hibernate.boot.internal.MetadataBuilderImpl.build(MetadataBuilderImpl.java:85)
        at org.arfna.database.HibernateUtil.getSessionFactory(HibernateUtil.java:29)
        at org.arfna.database.DatabaseUtil.getSubscriberFromEmail(DatabaseUtil.java:96)
        at org.arfna.method.password.login.MutateSubscriberUtil.login(MutateSubscriberUtil.java:53)
        at org.arfna.method.password.login.api.MutateSubscriberApiV1.getResponse(MutateSubscriberApiV1.java:31)
        at org.arfna.api.endpoints.MutateSubscriberUtility.getResponse(MutateSubscriberUtility.java:17)
        at org.arfna.api.ArfnaUtility.getMutateSubscriberResponse(ArfnaUtility.java:30)
        at org.arfna.service.ServiceClient.getMutateSubscriberResponse(ServiceClient.java:25)
        at org.arfna.service.ServiceClient.execute(ServiceClient.java:61)
        at org.arfna.Servlet.doPost(Servlet.java:53)
```

I tested this in the [dev server](http://JavaTestLoadBalancer-335255745.us-west-2.elb.amazonaws.com/arfna/api) from insomnia