### PR TITLE
CU-3xwha0u: Added admin methods

### DIFF
--- a/arfna-backend/README.md
+++ b/arfna-backend/README.md
@@ -77,6 +77,9 @@
 This API cannot be used unless a valid cookie has been transferred using the LOGIN API from the mutate subscriber API.
 
 **Getting all posts that subscriber has authored**
+
+
+If the role is admin, it will get all posts greater than or equal to submitted for the admin to see. 
 ```json
 {
     "version": "V1",

--- a/arfna-backend/src/main/java/org/arfna/database/DatabaseUtil.java
+++ b/arfna-backend/src/main/java/org/arfna/database/DatabaseUtil.java
@@ -7,9 +7,11 @@ import org.hibernate.Session;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class DatabaseUtil {
@@ -142,6 +144,34 @@ public class DatabaseUtil {
             return posts;
         } catch (Exception e) {
             ArfnaLogger.exception(DatabaseUtil.class, "Exception occurred when fetching published posts", e);
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * This is a unique logic method.
+     * It will only get posts that are passed the submitted stage so the admin can look at it.
+     * It will also only pull posts that aren't written by admin, assuming that the rest of the posts were retrieved
+     * earlier.
+     * @return List<Post> filtered appropriately as by above.
+     */
+    public List<Post> getAllPostsForAdminView(int subscriberId) {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            session.beginTransaction();
+            CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+            CriteriaQuery<Post> query = criteriaBuilder.createQuery(Post.class);
+            Root<Post> root = query.from(Post.class);
+            query.select(root)
+                    .where(Arrays.asList(
+                            criteriaBuilder.equal(root.get("isSubmitted"), true),
+                            criteriaBuilder.notEqual(root.get("author"), subscriberId)
+                    ).toArray(new Predicate[0]))
+                    .orderBy(criteriaBuilder.desc(root.get("lastUpdated")));
+            List<Post> posts = session.createQuery(query).getResultList();
+            session.getTransaction().commit();
+            return posts;
+        } catch (Exception e) {
+            ArfnaLogger.exception(DatabaseUtil.class, "Exception occurred when fetching all submitted posts for admin view", e);
         }
         return new ArrayList<>();
     }

--- a/arfna-backend/src/main/java/org/arfna/method/blog/mutation/MutatePostResponse.java
+++ b/arfna-backend/src/main/java/org/arfna/method/blog/mutation/MutatePostResponse.java
@@ -34,9 +34,18 @@ public class MutatePostResponse extends MethodResponse implements Serializable {
 
     private void prepareForSerialization() {
         if (this.allPosts != null)
-            this.allPosts.forEach(x -> x.setAuthor(null));
-        if (this.post != null)
-            this.post.setAuthor(null);
+            this.allPosts.stream().filter(x -> x.getAuthor() != null).forEach(x -> {
+                x.getAuthor().setPostsToNull();
+                x.getAuthor().setPassword(null);
+                x.getAuthor().setRole(null);
+                x.getAuthor().setEmailAddress(null);
+            });
+        if (this.post != null && this.post.getAuthor() != null) {
+            this.post.getAuthor().setPostsToNull();
+            this.post.getAuthor().setPassword(null);
+            this.post.getAuthor().setRole(null);
+            this.post.getAuthor().setEmailAddress(null);
+        }
     }
 
 }


### PR DESCRIPTION
If user has admin role, `mpost GET_FOR_SUBSCRIBER` will pull all the posts. It will display author when fetching data for filtering. This response is for id 14 when I upgraded them to be admin. It will show their posts (draft onwards), and any other individual posts that have been submitted onwards

Recall the following too:
submitted = `isSubmitted && !isAccepted && !isPublished`
accepted = `isSubmitted && isAccepted && !isPublished`
published = `isSubmitted && isAccepted && isPublished`

```
{
	"status": {
		"code": 200,
		"message": "OK"
	},
	"response": {
		"allPosts": [
			{
				"id": 8,
				"author": {
					"id": 17,
					"name": "Test Account"
				},
				"title": "My brand new post",
				"summary": "With a brief description",
				"markdown": "It's not quite done, but I wanna add more stuff. It's ready",
				"isSubmitted": true,
				"isAccepted": false,
				"isPublished": false,
				"createdAt": "Mar 30, 2022, 8:36:42 PM",
				"lastUpdated": "Mar 30, 2022, 8:37:26 PM"
			},
			{
				"id": 9,
				"author": {
					"id": 17,
					"name": "Test Account"
				},
				"isSubmitted": false,
				"isAccepted": false,
				"isPublished": false,
				"createdAt": "Jun 8, 2022, 10:03:05 PM",
				"lastUpdated": "Jun 8, 2022, 10:03:05 PM"
			},
			{
				"id": 6,
				"author": {
					"id": 14,
					"name": "Roshnee Sharma"
				},
				"title": "My newest post",
				"markdown": "I was very confident this time that I didn't even save!",
				"isSubmitted": true,
				"isAccepted": true,
				"isPublished": true,
				"createdAt": "Nov 30, 2021, 5:58:06 PM",
				"lastUpdated": "Nov 30, 2021, 6:24:55 PM"
			},
			{
				"id": 5,
				"author": {
					"id": 14,
					"name": "Roshnee Sharma"
				},
				"title": "My brand new post",
				"markdown": "It's not quite done, but I wanna finish it soon. Now I finally think it's ready",
				"isSubmitted": true,
				"createdAt": "Nov 30, 2021, 5:56:45 PM",
				"lastUpdated": "Nov 30, 2021, 5:57:39 PM"
			}
		]
	}
}
```