### PR TITLE
Accept cookies only for load balancer origin

### DIFF
--- a/server/src/main/java/org/arfna/Servlet.java
+++ b/server/src/main/java/org/arfna/Servlet.java
@@ -59,6 +59,7 @@ public class Servlet extends HttpServlet {
             response.addHeader("Access-Control-Allow-Headers", "Content-Type");
             response.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
             response.addHeader("Access-Control-Allow-Origin", "*");
+            response.addHeader("Access-Control-Allow-Credentials", "true");
             response.getWriter().println(GsonHelper.getGsonWithPrettyPrint().toJson(apiResponse));
         }
     }

--- a/server/src/main/java/org/arfna/Servlet.java
+++ b/server/src/main/java/org/arfna/Servlet.java
@@ -81,6 +81,7 @@ public class Servlet extends HttpServlet {
         resp.setHeader("Allow", allow.toString());
         resp.addHeader("Access-Control-Allow-Headers", "Content-Type");
         resp.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+        resp.addHeader("Access-Control-Allow-Credentials", "true");
         resp.addHeader("Access-Control-Allow-Origin", "*");
     }
 

--- a/server/src/main/java/org/arfna/Servlet.java
+++ b/server/src/main/java/org/arfna/Servlet.java
@@ -52,13 +52,14 @@ public class Servlet extends HttpServlet {
         } else {
             ServiceClient client = new ServiceClient();
             Optional<Subscriber> subscriberCookie = getSubscriberCookie(request);
+//            request.getHeader("origin");
             ApiResponse apiResponse = client.execute(request.getInputStream(), endpoint[1], subscriberCookie);
             addCookies(apiResponse, response);
             removeCookies(apiResponse, request, response);
             response.setStatus(apiResponse.getStatus().getCode());
             response.addHeader("Access-Control-Allow-Headers", "Content-Type");
             response.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-            response.addHeader("Access-Control-Allow-Origin", "http://webservertestloadbalancer-1421403146.us-west-2.elb.amazonaws.com");
+            response.addHeader("Access-Control-Allow-Origin", "*arfna.org");
             response.addHeader("Access-Control-Allow-Credentials", "true");
             response.getWriter().println(GsonHelper.getGsonWithPrettyPrint().toJson(apiResponse));
         }
@@ -83,7 +84,7 @@ public class Servlet extends HttpServlet {
         resp.addHeader("Access-Control-Allow-Headers", "Content-Type");
         resp.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         resp.addHeader("Access-Control-Allow-Credentials", "true");
-        resp.addHeader("Access-Control-Allow-Origin", "http://webservertestloadbalancer-1421403146.us-west-2.elb.amazonaws.com");
+        resp.addHeader("Access-Control-Allow-Origin", "*arfna.org");
     }
 
 

--- a/server/src/main/java/org/arfna/Servlet.java
+++ b/server/src/main/java/org/arfna/Servlet.java
@@ -58,7 +58,7 @@ public class Servlet extends HttpServlet {
             response.setStatus(apiResponse.getStatus().getCode());
             response.addHeader("Access-Control-Allow-Headers", "Content-Type");
             response.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-            response.addHeader("Access-Control-Allow-Origin", "*");
+            response.addHeader("Access-Control-Allow-Origin", "http://webservertestloadbalancer-1421403146.us-west-2.elb.amazonaws.com");
             response.addHeader("Access-Control-Allow-Credentials", "true");
             response.getWriter().println(GsonHelper.getGsonWithPrettyPrint().toJson(apiResponse));
         }
@@ -83,7 +83,7 @@ public class Servlet extends HttpServlet {
         resp.addHeader("Access-Control-Allow-Headers", "Content-Type");
         resp.addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         resp.addHeader("Access-Control-Allow-Credentials", "true");
-        resp.addHeader("Access-Control-Allow-Origin", "*");
+        resp.addHeader("Access-Control-Allow-Origin", "http://webservertestloadbalancer-1421403146.us-west-2.elb.amazonaws.com");
     }
 
 


### PR DESCRIPTION
This is for now, this should work. I'll update the code to have an allowlist of domains since we can only hardcode one to be allowed if we want to accept credentials

In parallel I'll work on transferring over the website to point to these so maybe we can even get around some of these cors issues.